### PR TITLE
feat: admin node pool

### DIFF
--- a/stage0/aws-eksctl/cluster.yaml
+++ b/stage0/aws-eksctl/cluster.yaml
@@ -12,6 +12,52 @@ metadata:
 
 managedNodeGroups:
   # Consistent
+  - name: co-ad-x86-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: admin
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instanceType: m6a.large
+    minSize: 1
+    maxSize: 1
+    desiredCapacity: 1
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "admin"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availabilityZones:
+      - us-west-2b
+
+  - name: co-ad-x86-az2
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: admin
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az2
+    instanceType: m6a.large
+    minSize: 0
+    maxSize: 1
+    desiredCapacity: 0
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "admin"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availabilityZones:
+      - us-west-2c
+
   - name: co-gp-x86-az1
     labels:
       demeter.run/availability-sla: consistent

--- a/stage0/aws-terraform/backend.tf.example
+++ b/stage0/aws-terraform/backend.tf.example
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    bucket = "BUCKET_NAME"
-    key = "stage0.tfstate"
-    region = "REGION"
+    bucket         = "BUCKET_NAME"
+    key            = "stage0.tfstate"
+    region         = "REGION"
     dynamodb_table = "terraform-state-lock"
-    encrypt = true
-    kms_key_id = "alias/terraform-state"
+    encrypt        = true
+    kms_key_id     = "alias/terraform-state"
   }
 }

--- a/stage0/aws-terraform/main.tf
+++ b/stage0/aws-terraform/main.tf
@@ -151,13 +151,13 @@ module "aws_cluster_eks" {
           {
             key : "demeter.run/compute-profile",
             operator : "Equal",
-            value : "general-purpose",
+            value : "admin",
             effect : "NoSchedule"
           },
           {
             key : "demeter.run/availability-sla",
             operator : "Equal",
-            value : "best-effort",
+            value : "consistent",
             effect : "NoSchedule"
           },
         ]


### PR DESCRIPTION
Create a set of smaller admin nodes, so we can target non-customer payloads to a specific set of nodes.