### PR TITLE
feat(example): add httproute, RBAC and Gateway API resources for Kong

### DIFF
--- a/examples/gateway.yaml
+++ b/examples/gateway.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kong-gateway-api
+rules:
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+      [
+        "httproutes",
+        "referencegrants",
+        "gatewayclasses",
+        "gatewayclasses/status",
+      ]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways", "gateways/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-gateway-api-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-gateway-api
+subjects:
+  - kind: ServiceAccount
+    name: kong-kong
+    namespace: dmtr-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kong-namespace-gateway
+  namespace: prj-example-1
+rules:
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways", "httproutes", "httproutes/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kong-namespace-gateway-binding
+  namespace: prj-example-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kong-namespace-gateway
+subjects:
+  - kind: ServiceAccount
+    name: kong-kong
+    namespace: dmtr-system
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kong
+  annotations:
+    konghq.com/gatewayclass-unmanaged: "true"
+
+spec:
+  controllerName: konghq.com/kic-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+  namespace: prj-example-1
+spec:
+  gatewayClassName: kong
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/examples/httproute.yaml
+++ b/examples/httproute.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prj-example-1-frontend-route
+  namespace: prj-example-1
+  annotations:
+    konghq.com/strip-path: 'true'
+spec:
+  parentRefs:
+  - name: kong
+  hostnames:
+  - bar.dmtr.host
+  rules:
+  - backendRefs:
+    - name: prj-example-1-frontend-service
+      kind: Service
+      port: 80


### PR DESCRIPTION
This commit introduces necessary RBAC permissions for the Kong service account to manage Gateway and HTTPRoute resources within the 'prj-example-1' namespace. It includes the creation of Roles and RoleBindings to ensure the Kong Ingress Controller can update the status of HTTPRoute resources and manage Gateway configurations effectively. Additionally, this commit adds the Gateway and HTTPRoute resources to enable routing configurations through Kong for the 'prj-example-1' frontend service.