### PR TITLE
feat(stage3): Add header rendered-by to identify provider

### DIFF
--- a/stage3/kong.tf
+++ b/stage3/kong.tf
@@ -78,6 +78,32 @@ resource "kubernetes_manifest" "kong_ping_endpoint_request_termination_plugin" {
   }
 }
 
+resource "kubernetes_manifest" "kong_response_transformer_plugin" {
+  manifest = {
+    apiVersion = "configuration.konghq.com/v1"
+    kind       = "KongClusterPlugin"
+
+    metadata = {
+      name = "kong-response-transformer"
+      labels = {
+        "konghq.com/plugin" = "response-transformer"
+        "global"            = "true"
+      }
+      annotations = {
+        "kubernetes.io/ingress.class" = "kong"
+      }
+    }
+    "plugin" = "response-transformer"
+    "config" = {
+      "add" = {
+        "headers" = [
+          "Rendered-By:${var.provider_name}",
+        ]
+      }
+    }
+  }
+}
+
 resource "kubernetes_manifest" "kong_prometheus_plugin" {
   manifest = {
     apiVersion = "configuration.konghq.com/v1"

--- a/stage3/variables.tf
+++ b/stage3/variables.tf
@@ -19,3 +19,8 @@ variable "cluster_name" {
 variable "cloudflared_token" {
   description = "token to authenticate with cloudflared tunnel"
 }
+
+variable "provider_name" {
+  description = "name of the provider"
+  default     = "TxPipe.io"
+}


### PR DESCRIPTION
```
curl -I https://foo.dmtr.host/
HTTP/2 200
date: Wed, 13 Mar 2024 16:28:50 GMT
content-type: text/html; charset=utf-8
rendered-by: TxPipe.io
```