### PR TITLE
feat: remove stage0 aws-terraform's aws-eksctl dependency

### DIFF
--- a/common/defaults.yaml
+++ b/common/defaults.yaml
@@ -1,8 +1,221 @@
 cloud_provider: k3d # TODO: switch to aws
 cluster_name: dmtr-cluster
 region: us-west-2
-azs: us-west-2b,us-west-2c
+azs:
+  - us-west-2b
+  - us-west-2c
 vpc_cidr: "10.6.0.0/16"
-managed_node_groups: []
 dmtr_namespace: dmtr-system
 dmtr_context: k3d-dmtr-cluster
+managed_node_groups:
+  # Consistent
+  - name: co-ad-x86-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: admin
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: t3a.medium
+    min_size: 1
+    max_size: 2
+    desired_capacity: 2
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "admin"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2b
+
+  - name: co-ad-x86-az2
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: admin
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az2
+    instance_type: m6a.large
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "admin"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2c
+
+  - name: co-gp-x86-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: m6a.2xlarge
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2b
+
+  - name: co-gp-x86-az2
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: m6a.2xlarge
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2c
+
+  - name: co-gp-arm64-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: arm64
+      demeter.run/availability-zone: az1
+    instance_type: m7g.2xlarge
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "arm64"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2b
+
+  - name: co-mem-x86-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: mem-intensive
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: r6a.2xlarge
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "mem-intensive"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2b
+
+  - name: co-mem-arm64-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: mem-intensive
+      demeter.run/compute-arch: arm64
+      demeter.run/availability-zone: az1
+    instance_type: r7g.2xlarge
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "mem-intensive"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "arm64"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2b
+
+  # Best Effort
+  - name: be-gp-x86-az1
+    labels:
+      demeter.run/availability-sla: best-effort
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_types:
+      ["m6a.2xlarge", "m6i.2xlarge", "t3.2xlarge", "m5.2xlarge", "m5a.2xlarge"]
+    min_size: 0
+    max_size: 1
+    desired_capacity: 1
+    spot: true
+    taints:
+      - key: demeter.run/availability-sla
+        value: "best-effort"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2b
+
+  - name: be-gp-arm64-az1
+    labels:
+      demeter.run/availability-sla: best-effort
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: arm64
+      demeter.run/availability-zone: az1
+    instance_types: ["m7g.2xlarge", "m6g.2xlarge", "t4g.2xlarge"]
+    min_size: 0
+    max_size: 1
+    desired_capacity: 1
+    spot: true
+    taints:
+      - key: demeter.run/availability-sla
+        value: "best-effort"
+        effect: NoSchedule
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NoSchedule
+      - key: demeter.run/compute-arch
+        value: "arm64"
+        effect: NoSchedule
+    availability_zones:
+      - us-west-2b

--- a/stage0/aws-eksctl/cluster.yaml
+++ b/stage0/aws-eksctl/cluster.yaml
@@ -222,5 +222,3 @@ managedNodeGroups:
         effect: NoSchedule
     availabilityZones:
       - us-west-2b
-
-


### PR DESCRIPTION
Breaks the dependency on defaults sourced from the `stage0/aws-eksctl/cluster.yaml` and moves it all into `common/defaults.yaml` which is shared between stage0 and bootstrap.

BREAKING CHANGE: top-level override file `config.yaml` camelCase is now snake_case