### PR TITLE
feat: use GKE module and defaults-gcp.yaml config

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -162,6 +162,15 @@ if [[ ${__cloud} == aws ]]; then
 
 elif [[ ${__cloud} == gcp ]]; then
 
+  cd ${__root}/stage0/gcp-terraform
+  if ! test -e backend.tf; then
+    echo configuring stage0 backend
+    sed -e "s#BUCKET_NAME#${__bucket}#" \
+        -e "s#REGION#${__region}#" \
+        backend.tf.example > backend.tf
+  fi
+  terraform init
+
   cd ${__root}/stage1
   if ! test -e backend.tf; then
     echo configuring stage1 backend

--- a/common/defaults-gcp.yaml
+++ b/common/defaults-gcp.yaml
@@ -1,3 +1,221 @@
-# TODO: add GCP defaults
-region: us-east4
+cloud_provider: gcp
+cluster_name: dmtr-cluster
+region: us-west2
+azs:
+  - us-west2-b
+  - us-west2-c
+vpc_cidr: "10.6.0.0/16"
+dmtr_namespace: dmtr-system
+dmtr_context: k3d-dmtr-cluster
+managed_node_groups:
+  # Consistent
+  - name: co-ad-x86-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: admin
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: e2-medium
+    min_size: 1
+    max_size: 2
+    desired_capacity: 1
+    disk_size_gb: 100
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "admin"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-b
 
+  - name: co-ad-x86-az2
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: admin
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az2
+    instance_type: n4-standard-8
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    disk_size_gb: 100
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "admin"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-c
+
+  - name: co-gp-x86-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: n4-standard-8
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    disk_size_gb: 100
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-b
+
+  - name: co-gp-x86-az2
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: n4-standard-8
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    disk_size_gb: 100
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-c
+
+  - name: co-gp-arm64-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: arm64
+      demeter.run/availability-zone: az1
+    instance_type: t2a-standard-8
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    disk_size_gb: 100
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "arm64"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-b
+
+  - name: co-mem-x86-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: mem-intensive
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: n4-highmem-8
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    disk_size_gb: 100
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "mem-intensive"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-b
+
+  - name: co-mem-arm64-az1
+    labels:
+      demeter.run/availability-sla: consistent
+      demeter.run/compute-profile: mem-intensive
+      demeter.run/compute-arch: arm64
+      demeter.run/availability-zone: az1
+    instance_type: t2a-standard-16
+    min_size: 0
+    max_size: 1
+    desired_capacity: 0
+    disk_size_gb: 100
+    taints:
+      - key: demeter.run/availability-sla
+        value: "consistent"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "mem-intensive"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "arm64"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-b
+
+  # Best Effort
+  - name: be-gp-x86-az1
+    labels:
+      demeter.run/availability-sla: best-effort
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: x86
+      demeter.run/availability-zone: az1
+    instance_type: n4-standard-8
+    min_size: 0
+    max_size: 1
+    desired_capacity: 1
+    disk_size_gb: 100
+    spot: true
+    taints:
+      - key: demeter.run/availability-sla
+        value: "best-effort"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "x86"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-b
+
+  - name: be-gp-arm64-az1
+    labels:
+      demeter.run/availability-sla: best-effort
+      demeter.run/compute-profile: general-purpose
+      demeter.run/compute-arch: arm64
+      demeter.run/availability-zone: az1
+  # Google supports one instance type per node group
+    instance_type: t2a-standard-8
+    min_size: 0
+    max_size: 1
+    desired_capacity: 1
+    disk_size_gb: 100
+    spot: true
+    taints:
+      - key: demeter.run/availability-sla
+        value: "best-effort"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-profile
+        value: "general-purpose"
+        effect: NO_SCHEDULE
+      - key: demeter.run/compute-arch
+        value: "arm64"
+        effect: NO_SCHEDULE
+    availability_zones: us-west2-b


### PR DESCRIPTION
Closes: #105 

Example of one node pool from the config

```
 # module.gke.google_container_node_pool.pools["co-mem-x86-az1"] will be created
  + resource "google_container_node_pool" "pools" {
      + cluster                     = "dmtr-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-east4"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "co-mem-x86-az1"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = [
          + "us-west2-b",
        ]
      + operation                   = (known after apply)
      + project                     = "blinklabs-demeter"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 1
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = true
        }

      + node_config {
          + disk_size_gb      = 100
          + disk_type         = "pd-ssd"
          + effective_taints  = (known after apply)
          + guest_accelerator = (known after apply)
          + image_type        = "COS_CONTAINERD"
          + labels            = {
              + "cluster_name"                  = "dmtr-cluster"
              + "demeter.run/availability-sla"  = "consistent"
              + "demeter.run/availability-zone" = "az1"
              + "demeter.run/compute-arch"      = "x86"
              + "demeter.run/compute-profile"   = "mem-intensive"
              + "node_pool"                     = "co-mem-x86-az1"
            }
          + local_ssd_count   = 0
          + logging_variant   = "DEFAULT"
          + machine_type      = "n4-highmem-8"
          + metadata          = {
              + "cluster_name"             = "dmtr-cluster"
              + "disable-legacy-endpoints" = "true"
              + "node_pool"                = "co-mem-x86-az1"
            }
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/logging.write",
              + "https://www.googleapis.com/auth/monitoring",
            ]
          + preemptible       = false
          + service_account   = "terraform-runner@blinklabs-demeter.iam.gserviceaccount.com"
          + spot              = false
          + tags              = [
              + "gke-dmtr-cluster",
              + "gke-dmtr-cluster-co-mem-x86-az1",
            ]
            # (1 unchanged attribute hidden)

          + shielded_instance_config {
              + enable_integrity_monitoring = true
              + enable_secure_boot          = false
            }

          + taint {
              + effect = "NO_SCHEDULE"
              + key    = "demeter.run/availability-sla"
              + value  = "consistent"
            }
          + taint {
              + effect = "NO_SCHEDULE"
              + key    = "demeter.run/compute-profile"
              + value  = "mem-intensive"
            }
          + taint {
              + effect = "NO_SCHEDULE"
              + key    = "demeter.run/compute-arch"
              + value  = "x86"
            }

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }

      + timeouts {
          + create = "45m"
          + delete = "45m"
          + update = "45m"
        }

      + upgrade_settings {
          + max_surge       = 1
          + max_unavailable = 0
          + strategy        = "SURGE"
        }
    }
    
   ```
    