### PR TITLE
feat: cert-manager stage1 for crds

### DIFF
--- a/stage1/main.tf
+++ b/stage1/main.tf
@@ -55,9 +55,9 @@ module "k3d_storage_classes" {
 #   source = "../modules/common/metrics-server/stage1"
 # }
 
-# module "cert_manager" {
-#   source = "../modules/common/cert-manager/stage1"
-# }
+module "cert_manager" {
+  source = "../modules/common/cert-manager/stage1"
+}
 
 module "o11y" {
   source     = "../modules/common/o11y/stage1"


### PR DESCRIPTION
These are necessary for extensions like ext-cardano-node to be installed.