### PR TITLE
feat: add ext-utxorpc

### DIFF
--- a/stage3/kupo.tf
+++ b/stage3/kupo.tf
@@ -91,16 +91,3 @@ module "ext_cardano_kupo" {
   }
 }
 
-# Replacement storage class for kupo instead of using the nvme storage class by default
-resource "kubernetes_storage_class_v1" "gp_immediate" {
-  metadata {
-    name = "gp-immediate"
-  }
-  storage_provisioner    = "pd.csi.storage.gke.io"
-  reclaim_policy         = "Delete"
-  volume_binding_mode    = "Immediate"
-  allow_volume_expansion = true
-  parameters = {
-    type = "pd-balanced"
-  }
-}

--- a/stage3/main.tf
+++ b/stage3/main.tf
@@ -18,3 +18,25 @@ provider "helm" {
     config_context = var.k8s_context
   }
 }
+
+# Placeholder/Replacement storage class for kupo, utxorpc instead of using the nvme storage class by default
+resource "kubernetes_storage_class_v1" "gp_immediate" {
+  for_each = toset([for t in toset(["gp-immediate"]) : t if var.cloud_provider == "gcp" || var.cloud_provider == "aws"])
+  metadata {
+    name = "gp-immediate"
+  }
+
+  storage_provisioner = var.cloud_provider == "gcp" ? "pd.csi.storage.gke.io" : "kubernetes.io/aws-ebs"
+  reclaim_policy      = "Delete"
+  volume_binding_mode = "Immediate"
+
+  allow_volume_expansion = true
+
+  parameters = var.cloud_provider == "gcp" ? {
+    type = "pd-balanced"
+    } : {
+    type      = "gp3"
+    fsType    = "ext4"
+    encrypted = "true"
+  }
+}

--- a/stage3/utxorpc.tf
+++ b/stage3/utxorpc.tf
@@ -1,0 +1,140 @@
+locals {
+  // Defaults for UtxoRPC
+  utxorpc_defaults = {
+    namespace             = "ext-utxorpc-m0"
+    dns_zone              = "utxorpc.cloud"
+    operator_image_tag    = "40389c34949a6ac5d72d5a887164a6950e1924a0"
+    networks              = ["cardano-mainnet", "cardano-preprod", "cardano-preview"]
+    cloudflared_image_tag = "latest"
+    cloudflared_replicas  = 0
+    cloudflared_resources = {
+      limits = {
+        cpu    = "2"
+        memory = "500Mi"
+      }
+      requests = {
+        cpu    = "50m"
+        memory = "500Mi"
+      }
+    }
+    cloudflared_tolerations = [
+      {
+        effect   = "NoSchedule"
+        key      = "demeter.run/compute-profile"
+        operator = "Exists"
+      },
+      {
+        effect   = "NoSchedule"
+        key      = "demeter.run/compute-arch"
+        operator = "Exists"
+      },
+      {
+        effect   = "NoSchedule"
+        key      = "demeter.run/availability-sla"
+        operator = "Exists"
+      }
+    ]
+    proxies_image_tag = "40389c34949a6ac5d72d5a887164a6950e1924a0"
+    proxies_replicas  = 0
+    proxies_resources = {
+      limits = {
+        cpu    = "2"
+        memory = "250Mi"
+      }
+      requests = {
+        cpu    = "50m"
+        memory = "250Mi"
+      }
+    }
+    proxies_tolerations = [
+      {
+        effect   = "NoSchedule"
+        key      = "demeter.run/compute-profile"
+        operator = "Exists"
+      },
+      {
+        effect   = "NoSchedule"
+        key      = "demeter.run/compute-arch"
+        operator = "Equal"
+        value    = "x86"
+      },
+      {
+        effect   = "NoSchedule"
+        key      = "demeter.run/availability-sla"
+        operator = "Exists"
+      }
+    ]
+    cloudflared_tunnel_id     = "default-tunnel-id"
+    cloudflared_tunnel_secret = "default-tunnel-secret"
+    cloudflared_account_tag   = "default-account-tag"
+    extension_subdomain       = "utxorpc"
+    api_key_salt              = "this is a random generated key and must be shared..."
+  }
+}
+
+module "ext_cardano_utxorpc" {
+  # source   = "git::https://github.com/demeter-run/ext-cardano-utxorpc//bootstrap/"
+  source   = "git::https://github.com/verbotenj/ext-cardano-utxorpc.git//bootstrap?ref=feat/use-unnamed-volume"
+  for_each = toset([for n in toset(["v1"]) : n if var.enable_cardano_utxorpc])
+
+  operator_image_tag  = local.utxorpc_defaults.operator_image_tag
+  extension_subdomain = local.utxorpc_defaults.extension_subdomain
+  dns_zone            = local.utxorpc_defaults.dns_zone
+  api_key_salt        = local.utxorpc_defaults.api_key_salt
+  namespace           = local.utxorpc_defaults.namespace
+  networks            = local.utxorpc_defaults.networks
+
+  network_addresses = {
+    # "cardano-mainnet" : "relay.utxorpc-m0.demeter.run:3000"
+    "cardano-preprod" : "relay.utxorpc-m0.demeter.run:3001"
+    # "cardano-preview" : "relay.utxorpc-m0.demeter.run:3002"
+  }
+
+  // Cloudflared
+  cloudflared_tunnel_id     = local.utxorpc_defaults.cloudflared_tunnel_id
+  cloudflared_tunnel_secret = local.utxorpc_defaults.cloudflared_tunnel_secret
+  cloudflared_account_tag   = local.utxorpc_defaults.cloudflared_account_tag
+  cloudflared_image_tag     = local.utxorpc_defaults.cloudflared_image_tag
+  cloudflared_replicas      = local.utxorpc_defaults.cloudflared_replicas
+  cloudflared_resources     = local.utxorpc_defaults.cloudflared_resources
+  cloudflared_tolerations   = local.utxorpc_defaults.cloudflared_tolerations
+
+  // Proxies
+  proxies_image_tag   = local.utxorpc_defaults.proxies_image_tag
+  proxies_replicas    = local.utxorpc_defaults.proxies_replicas
+  proxies_resources   = local.utxorpc_defaults.proxies_resources
+  proxies_tolerations = local.utxorpc_defaults.proxies_tolerations
+
+  cells = {
+    "cell1" = {
+      # tolerations = [
+      #   {
+      #     effect   = "NoSchedule"
+      #     key      = "demeter.run/compute-arch"
+      #     operator = "Equal"
+      #     value    = "arm64"
+      #   }
+      # ]
+      pvc = {
+        storage_class = "gp-immediate"
+        storage_size  = "30Gi"
+      }
+      instances = {
+        "cardano-preprod" = {
+          dolos_version = "sha-1618ebb"
+          replicas      = 1
+          resources = {
+            limits = {
+              cpu    = "1000m"
+              memory = "8Gi"
+            }
+            requests = {
+              cpu    = "50m"
+              memory = "512Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/stage3/variables.tf
+++ b/stage3/variables.tf
@@ -58,3 +58,13 @@ variable "enable_cardano_ogmios" {
   description = "enable ext-cardano-ogmios support"
   default     = false
 }
+
+variable "enable_cardano_utxorpc" {
+  description = "enable ext-cardano-utxorpc support"
+  default     = false
+}
+
+variable "utxorpc" {
+  description = "Configuration for the UtxoRPC extension"
+  default     = {}
+}


### PR DESCRIPTION
Fixes #133 

- utxorpc as relies on gp_immediate storage_class. It's currently a placeholder for `nvme`
- relates https://github.com/demeter-run/ext-cardano-utxorpc/pull/11

```
2024-09-03T17:47:00.426915Z  INFO stage{stage="ledger"}:execute: dolos::sync::ledger: applying block slot=2858547
2024-09-03T17:47:00.427099Z  INFO stage{stage="roll"}:execute: dolos::sync::roll: extending wal block.slot=2858551 block.hash=b73e3274c0f16750ff8625883ce5d15cb4e11d89bc23439ef55c7c6a6af3c81f
2024-09-03T17:47:00.428083Z  INFO stage{stage="ledger"}:execute: dolos::sync::ledger: applying block slot=2858551
```