### PR TITLE
fix: use --protocol http2 for cloudflared for grpc

### DIFF
--- a/stage3/cloudflared.tf
+++ b/stage3/cloudflared.tf
@@ -38,6 +38,8 @@ resource "kubernetes_deployment" "cloudflared" {
           args = [
             "tunnel",
             "--no-autoupdate",
+            "--protocol",
+            "http2",
             "--metrics",
             "0.0.0.0:60123",
             "run",


### PR DESCRIPTION
This has been applied to blinklabs-us already.