### PR TITLE
fix: modernize GCP cluster

### DIFF
--- a/common/defaults-gcp.yaml
+++ b/common/defaults-gcp.yaml
@@ -23,7 +23,7 @@ managed_node_groups:
         effect: NO_SCHEDULE
     availability_zones: us-central1-a
 
-  # Enamble for HA
+  # Enable for HA
   - name: gke-system-az2
     labels:
       gke-managed-components: "true"
@@ -206,7 +206,7 @@ managed_node_groups:
       demeter.run/compute-profile: mem-intensive
       demeter.run/compute-arch: arm64
       demeter.run/availability-zone: az1
-    instance_type: c4a-highmem-8
+    instance_type: c4a-highmem-16
     min_size: 0
     max_size: 1
     desired_capacity: 0
@@ -229,7 +229,7 @@ managed_node_groups:
       demeter.run/compute-profile: mem-intensive
       demeter.run/compute-arch: arm64
       demeter.run/availability-zone: az2
-    instance_type: c4a-highmem-8
+    instance_type: c4a-highmem-16
     min_size: 0
     max_size: 1
     desired_capacity: 0
@@ -245,55 +245,3 @@ managed_node_groups:
         value: "arm64"
         effect: NO_SCHEDULE
     availability_zones: us-central1-b
-
-  # Disk Intensive
-  - name: co-di-x86-az2
-    labels:
-      demeter.run/availability-sla: consistent
-      demeter.run/compute-profile: disk-intensive
-      demeter.run/compute-arch: x86
-      demeter.run/availability-zone: az1
-    instance_type: n2-standard-4
-    min_size: 0
-    max_size: 1
-    desired_capacity: 0
-    disk_size_gb: 100
-    disk_type: pd-ssd
-    spot: true
-    taints:
-      - key: demeter.run/availability-sla
-        value: "consistent"
-        effect: NO_SCHEDULE
-      - key: demeter.run/compute-profile
-        value: "disk-intensive"
-        effect: NO_SCHEDULE
-      - key: demeter.run/compute-arch
-        value: "x86"
-        effect: NO_SCHEDULE
-    availability_zones: us-central1-a
-
-  - name: co-di-arm64-az1
-    labels:
-      demeter.run/availability-sla: consistent
-      demeter.run/compute-profile: disk-intensive
-      demeter.run/compute-arch: arm64
-      demeter.run/availability-zone: az1
-  # Google supports one instance type per node group
-    instance_type: t2a-standard-4
-    min_size: 0
-    max_size: 1
-    desired_capacity: 1
-    disk_size_gb: 100
-    disk_type: pd-ssd
-    spot: true
-    taints:
-      - key: demeter.run/availability-sla
-        value: "consistent"
-        effect: NO_SCHEDULE
-      - key: demeter.run/compute-profile
-        value: "disk-intensive"
-        effect: NO_SCHEDULE
-      - key: demeter.run/compute-arch
-        value: "arm64"
-        effect: NO_SCHEDULE
-    availability_zones: us-central1-a

--- a/stage1/.terraform.lock.hcl
+++ b/stage1/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/helm" {
   version = "2.17.0"
   hashes = [
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/helm" {
 provider "registry.terraform.io/hashicorp/http" {
   version = "3.4.5"
   hashes = [
+    "h1:ceAVZEuaQd7jQX13qf5w7hy3ioiXpuwUaaDRsnAiMLM=",
     "h1:eSVCYfvn5JyV3LC0+mrLlLtgLv4B+RWeNqz02miBcMY=",
     "zh:2072006c177efc101471f3d5eb8e1d8e6c68778cbfd6db3d3f22f59cfe6ce6ae",
     "zh:3ac4cc0efe11ee054300769cfcc37491433937a8824621d1f8f7a18e7401da87",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.22.0"
   hashes = [
     "h1:DJr88+52tPK4Ft9xltF6YL+sRz8HWLP2ZOfFiKSB5Dc=",
+    "h1:b6Wj111/wsMNg8FrHFXrf4mCZFtSXKHx4JvbZh3YTCY=",
     "zh:1eac662b1f238042b2068401e510f0624efaf51fd6a4dd9c49d710a49d383b61",
     "zh:4c35651603493437b0b13e070148a330c034ac62c8967c2de9da6620b26adca4",
     "zh:50c0e8654efb46e3a3666c638ca2e0c8aec07f985fbc80f9205bed960386dc9b",
@@ -59,28 +62,10 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/local" {
-  version = "2.5.2"
-  hashes = [
-    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
-    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
-    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
-    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
-    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
-    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
-    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
-    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
-    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
-    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
-    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.3"
   hashes = [
+    "h1:+AnORRgFbRO6qqcfaQyeX80W0eX3VmjadjnUFUJTiXo=",
     "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
     "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
     "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",


### PR DESCRIPTION
Increase the size of the mem-arm64 instances and remove the disk-intensive instances as they're not necessary with hyperdisk.